### PR TITLE
Build: waf only build the 'copter' target

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -97,7 +97,7 @@ for t in $CI_BUILD_TARGET; do
         echo "Starting waf build for board ${t}..."
         $waf configure --board $t --enable-benchmarks --check-c-compiler="$c_compiler" --check-cxx-compiler="$cxx_compiler"
         $waf clean
-        $waf all
+        $waf copter
         ccache -s && ccache -z
 
         if [[ $t == linux ]]; then


### PR DESCRIPTION
This will prevent travis tests from failing due to changes incompatible with Rover & Plane.
The px4-v2-solo target is still handled by make.
