### PR TITLE
EKF2: Miscellaneous Estimation Improvements

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -21,7 +21,7 @@ AVCHOME=mavutil.location(40.072842,-105.230575,1586,0)
 
 homeloc = None
 num_wp = 0
-speedup_default = 5
+speedup_default = 10
 
 def hover(mavproxy, mav, hover_throttle=1450):
     mavproxy.send('rc 3 %u\n' % hover_throttle)
@@ -980,8 +980,8 @@ def fly_ArduCopter(binary, viewerip=None, map=False, valgrind=False):
         setup_rc(mavproxy)
         homeloc = mav.location()
 
-        # wait 10sec to allow EKF to settle
-        wait_seconds(mav, 10)
+        # wait 40sec for EKF and GPS checks to pass
+        wait_seconds(mav, 40)
 
         # Arm
         print("# Arm motors")

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -43,7 +43,8 @@
   space
  */
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 && (defined(CONFIG_ARCH_BOARD_PX4FMU_V1) || defined(CONFIG_ARCH_BOARD_PX4FMU_V2))
-#define AP_AHRS_WITH_EKF1 0
+// Solo can use additional flash space because of the STM32 chip revision in the PX2
+#define AP_AHRS_WITH_EKF1 1
 #else
 #define AP_AHRS_WITH_EKF1 1
 #endif

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -631,18 +631,6 @@ bool NavEKF::getOriginLLH(struct Location &loc) const
     return core->getOriginLLH(loc);
 }
 
-// set the latitude and longitude and height used to set the NED origin
-// All NED positions calcualted by the filter will be relative to this location
-// The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
-// Returns false if the filter has rejected the attempt to set the origin
-bool NavEKF::setOriginLLH(struct Location &loc)
-{
-    if (!core) {
-        return false;
-    }
-    return core->setOriginLLH(loc);
-}
-
 // return estimated height above ground level
 // return false if ground height is not being estimated.
 bool NavEKF::getHAGL(float &HAGL) const

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -402,6 +402,14 @@ const AP_Param::GroupInfo NavEKF::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("GPS_CHECK",    33, NavEKF, _gpsCheck, 31),
 
+    // @Param: CHECK_SCALE
+    // @DisplayName: GPS accuracy check scaler (%)
+    // @Description: This scales the thresholds that are used to check GPS accuracy before it is used by the EKF. A value of 100 is the default. Values greater than 100 increase and values less than 100 reduce the maximum GPS error the EKF will accept. A value of 200 will double the allowable GPS error.
+    // @Range: 50 200
+    // @User: Advanced
+    // @Units: %
+    AP_GROUPINFO("CHECK_SCALE", 35, NavEKF, _gpsCheckScaler, 100),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -142,12 +142,6 @@ public:
     // Returns false if the origin has not been set
     bool getOriginLLH(struct Location &loc) const;
 
-    // set the latitude and longitude and height used to set the NED origin
-    // All NED positions calcualted by the filter will be relative to this location
-    // The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
-    // Returns false if the filter has rejected the attempt to set the origin
-    bool setOriginLLH(struct Location &loc);
-
     // return estimated height above ground level
     // return false if ground height is not being estimated.
     bool getHAGL(float &HAGL) const;

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -290,5 +290,6 @@ private:
     AP_Int8 _fallback;              // EKF-to-DCM fallback strictness. 0 = trust EKF more, 1 = fallback more conservatively.
     AP_Int8 _altSource;             // Primary alt source during optical flow navigation. 0 = use Baro, 1 = use range finder.
     AP_Int8 _gpsCheck;              // Bitmask controlling which preflight GPS checks are bypassed
+    AP_Int16 _gpsCheckScaler;       // Percentage increase to be applied to GPS pre-flight accuracy and drift thresholds
 
 };

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -4850,17 +4850,6 @@ bool NavEKF_core::getOriginLLH(struct Location &loc) const
     return validOrigin;
 }
 
-// set the LLH location of the filters NED origin
-bool NavEKF_core::setOriginLLH(struct Location &loc)
-{
-    if (vehicleArmed) {
-        return false;
-    }
-    EKF_origin = loc;
-    validOrigin = true;
-    return true;
-}
-
 // determine if a takeoff is expected so that we can compensate for expected barometer errors due to ground effect
 bool NavEKF_core::getTakeoffExpected()
 {

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -4900,6 +4900,9 @@ bool NavEKF_core::calcGpsGoodToAlign(void)
 {
     static struct Location gpsloc_prev;    // LLH location of previous GPS measurement
 
+    // User defined multiplier to be applied to check thresholds
+    float checkScaler = 0.01f*(float)frontend._gpsCheckScaler;
+
     // calculate absolute difference between GPS vert vel and inertial vert vel
     float velDiffAbs;
     if (_ahrs->get_gps().have_vertical_velocity()) {
@@ -4909,7 +4912,7 @@ bool NavEKF_core::calcGpsGoodToAlign(void)
     }
 
     // fail if velocity difference or reported speed accuracy greater than threshold
-    bool gpsVelFail = ((velDiffAbs > 1.0f) || (gpsSpdAccuracy > 1.0f)) && (frontend._gpsCheck & MASK_GPS_SPD_ERR);
+    bool gpsVelFail = ((velDiffAbs > 1.0f) || (gpsSpdAccuracy > 1.0f*checkScaler)) && (frontend._gpsCheck & MASK_GPS_SPD_ERR);
 
     if (velDiffAbs > 1.0f) {
         hal.util->snprintf(prearm_fail_string,
@@ -4952,14 +4955,14 @@ bool NavEKF_core::calcGpsGoodToAlign(void)
     float hAcc = 0.0f;
     bool hAccFail;
     if (_ahrs->get_gps().horizontal_accuracy(hAcc)) {
-        hAccFail = (hAcc > 5.0f)  && (frontend._gpsCheck & MASK_GPS_POS_ERR);
+        hAccFail = (hAcc > 5.0f*checkScaler)  && (frontend._gpsCheck & MASK_GPS_POS_ERR);
     } else {
         hAccFail =  false;
     }
     if (hAccFail) {
         hal.util->snprintf(prearm_fail_string,
                            sizeof(prearm_fail_string),
-                           "GPS horiz error %.1f", (double)hAcc);
+                           "GPS horiz error %.1f", (double)hAcc, (double)(5.0f*checkScaler));
         gpsCheckStatus.bad_hAcc = true;
     } else {
         gpsCheckStatus.bad_hAcc = false;
@@ -5013,11 +5016,11 @@ bool NavEKF_core::calcGpsGoodToAlign(void)
     gpsDriftNE = MIN(gpsDriftNE,10.0f);
     // Fail if more than 3 metres drift after filtering whilst pre-armed when the vehicle is supposed to be stationary
     // This corresponds to a maximum acceptable average drift rate of 0.3 m/s or single glitch event of 3m
-    bool gpsDriftFail = (gpsDriftNE > 3.0f) && !vehicleArmed && (frontend._gpsCheck & MASK_GPS_POS_DRIFT);
+    bool gpsDriftFail = (gpsDriftNE > 3.0f*checkScaler) && !vehicleArmed && (frontend._gpsCheck & MASK_GPS_POS_DRIFT);
     if (gpsDriftFail) {
         hal.util->snprintf(prearm_fail_string,
                            sizeof(prearm_fail_string),
-                           "GPS drift %.1fm (needs 3.0)", (double)gpsDriftNE);
+                           "GPS drift %.1fm (needs %.1f)", (double)gpsDriftNE, (double)(3.0f*checkScaler));
         gpsCheckStatus.bad_horiz_drift = true;
     } else {
         gpsCheckStatus.bad_horiz_drift = false;
@@ -5029,7 +5032,7 @@ bool NavEKF_core::calcGpsGoodToAlign(void)
         // check that the average vertical GPS velocity is close to zero
         gpsVertVelFilt = 0.1f * velNED.z + 0.9f * gpsVertVelFilt;
         gpsVertVelFilt = constrain_float(gpsVertVelFilt,-10.0f,10.0f);
-        gpsVertVelFail = (fabsf(gpsVertVelFilt) > 0.3f) && (frontend._gpsCheck & MASK_GPS_VERT_SPD);
+        gpsVertVelFail = (fabsf(gpsVertVelFilt) > 0.3f*checkScaler) && (frontend._gpsCheck & MASK_GPS_VERT_SPD);
     } else if ((frontend._fusionModeGPS == 0) && !_ahrs->get_gps().have_vertical_velocity()) {
         // If the EKF settings require vertical GPS velocity and the receiver is not outputting it, then fail
         gpsVertVelFail = true;
@@ -5039,7 +5042,7 @@ bool NavEKF_core::calcGpsGoodToAlign(void)
     if (gpsVertVelFail) {
         hal.util->snprintf(prearm_fail_string,
                            sizeof(prearm_fail_string),
-                           "GPS vertical speed %.2fm/s (needs 0.30)", (double)fabsf(gpsVertVelFilt));
+                           "GPS vertical speed %.2fm/s (needs %.2f)", (double)fabsf(gpsVertVelFilt),(double)(0.3f*checkScaler));
         gpsCheckStatus.bad_vert_vel = true;
     } else {
         gpsCheckStatus.bad_vert_vel = false;
@@ -5050,14 +5053,14 @@ bool NavEKF_core::calcGpsGoodToAlign(void)
     if (!vehicleArmed) {
         gpsHorizVelFilt = 0.1f * norm(velNED.x,velNED.y) + 0.9f * gpsHorizVelFilt;
         gpsHorizVelFilt = constrain_float(gpsHorizVelFilt,-10.0f,10.0f);
-        gpsHorizVelFail = (fabsf(gpsHorizVelFilt) > 0.3f) && (frontend._gpsCheck & MASK_GPS_HORIZ_SPD);
+        gpsHorizVelFail = (fabsf(gpsHorizVelFilt) > 0.3f*checkScaler) && (frontend._gpsCheck & MASK_GPS_HORIZ_SPD);
     } else {
         gpsHorizVelFail = false;
     }
     if (gpsHorizVelFail) {
         hal.util->snprintf(prearm_fail_string,
                            sizeof(prearm_fail_string),
-                           "GPS horizontal speed %.2fm/s (needs 0.30)", (double)gpsDriftNE);
+                           "GPS horizontal speed %.2fm/s (needs %.2f)", (double)gpsDriftNE,(double)(0.3f*checkScaler));
         gpsCheckStatus.bad_horiz_vel = true;
     } else {
         gpsCheckStatus.bad_horiz_vel = false;

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -4942,10 +4942,10 @@ bool NavEKF_core::calcGpsGoodToAlign(void)
     }
 
     // fail if satellite geometry is poor
-    bool hdopFail = (_ahrs->get_gps().get_hdop() > 250)  && (frontend._gpsCheck & MASK_GPS_HDOP);
+    bool hdopFail = (_ahrs->get_gps().get_hdop() > 170)  && (frontend._gpsCheck & MASK_GPS_HDOP);
     if (hdopFail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS HDOP %.1f (needs 2.5)", (double)(0.01f * _ahrs->get_gps().get_hdop()));
+                           "GPS HDOP %.1f (needs 1.7)", (double)(0.01f * _ahrs->get_gps().get_hdop()));
         gpsCheckStatus.bad_hdop = true;
     } else {
         gpsCheckStatus.bad_hdop = false;

--- a/libraries/AP_NavEKF/AP_NavEKF_core.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.h
@@ -185,12 +185,6 @@ public:
     // Returns false if the origin has not been set
     bool getOriginLLH(struct Location &loc) const;
 
-    // set the latitude and longitude and height used to set the NED origin
-    // All NED positions calcualted by the filter will be relative to this location
-    // The origin cannot be set if the filter is in a flight mode (eg vehicle armed)
-    // Returns false if the filter has rejected the attempt to set the origin
-    bool setOriginLLH(struct Location &loc);
-
     // return estimated height above ground level
     // return false if ground height is not being estimated.
     bool getHAGL(float &HAGL) const;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -25,8 +25,8 @@
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     5.0E-03f
-#define MAGB_P_NSE_DEFAULT      5.0E-04f
-#define MAGE_P_NSE_DEFAULT      5.0E-03f
+#define MAGB_P_NSE_DEFAULT      1.0E-04f
+#define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
 #define POS_I_GATE_DEFAULT      500
 #define HGT_I_GATE_DEFAULT      500
@@ -50,8 +50,8 @@
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     5.0E-03f
-#define MAGB_P_NSE_DEFAULT      5.0E-04f
-#define MAGE_P_NSE_DEFAULT      5.0E-03f
+#define MAGB_P_NSE_DEFAULT      1.0E-04f
+#define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
 #define POS_I_GATE_DEFAULT      500
 #define HGT_I_GATE_DEFAULT      500
@@ -75,8 +75,8 @@
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     5.0E-03f
-#define MAGB_P_NSE_DEFAULT      5.0E-04f
-#define MAGE_P_NSE_DEFAULT      5.0E-03f
+#define MAGB_P_NSE_DEFAULT      1.0E-04f
+#define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
 #define POS_I_GATE_DEFAULT      500
 #define HGT_I_GATE_DEFAULT      500
@@ -100,8 +100,8 @@
 #define GBIAS_P_NSE_DEFAULT     1.0E-04f
 #define GSCALE_P_NSE_DEFAULT    5.0E-04f
 #define ABIAS_P_NSE_DEFAULT     5.0E-03f
-#define MAGB_P_NSE_DEFAULT      5.0E-04f
-#define MAGE_P_NSE_DEFAULT      5.0E-03f
+#define MAGB_P_NSE_DEFAULT      1.0E-04f
+#define MAGE_P_NSE_DEFAULT      1.0E-03f
 #define VEL_I_GATE_DEFAULT      500
 #define POS_I_GATE_DEFAULT      500
 #define HGT_I_GATE_DEFAULT      500

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -455,10 +455,10 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: TAU_OUTPUT
     // @DisplayName: Output complementary filter time constant (centi-sec)
     // @Description: Sets the time constant of the output complementary filter/predictor in centi-seconds.
-    // @Range: 5 30
+    // @Range: 10 50
     // @Increment: 5
     // @User: Advanced
-    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 20),
+    AP_GROUPINFO("TAU_OUTPUT", 39, NavEKF2, _tauVelPosOutput, 25),
 
     // @Param: MAGE_P_NSE
     // @DisplayName: Earth magnetic field process noise (gauss/s)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -111,9 +111,19 @@ void NavEKF2_core::setWindMagStateLearningMode()
         inhibitMagStates = true;
     } else if (inhibitMagStates && !setMagInhibit) {
         inhibitMagStates = false;
-        // when commencing use of magnetic field states, set the variances equal to the observation uncertainty
-        for (uint8_t index=16; index<=21; index++) {
-            P[index][index] = sq(frontend->_magNoise);
+        if (magFieldLearned) {
+            // if we have already learned the field states, then retain the learned variances
+            P[16][16] = earthMagFieldVar.x;
+            P[17][17] = earthMagFieldVar.y;
+            P[18][18] = earthMagFieldVar.z;
+            P[19][19] = bodyMagFieldVar.x;
+            P[20][20] = bodyMagFieldVar.y;
+            P[21][21] = bodyMagFieldVar.z;
+        } else {
+            // set the variances equal to the observation variances
+            for (uint8_t index=16; index<=21; index++) {
+                P[index][index] = sq(frontend->_magNoise);
+            }
         }
         // request a reset of the yaw and magnetic field states if not done before
         if (!magStateInitComplete || (!finalInflightMagInit && inFlight)) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -121,9 +121,14 @@ void NavEKF2_core::setWindMagStateLearningMode()
             P[21][21] = bodyMagFieldVar.z;
         } else {
             // set the variances equal to the observation variances
-            for (uint8_t index=16; index<=21; index++) {
+            for (uint8_t index=18; index<=21; index++) {
                 P[index][index] = sq(frontend->_magNoise);
             }
+
+            // set the NE earth magnetic field states using the published declination
+            // and set the corresponding variances and covariances
+            alignMagStateDeclination();
+
         }
         // request a reset of the yaw and magnetic field states if not done before
         if (!magStateInitComplete || (!finalInflightMagInit && inFlight)) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -164,7 +164,7 @@ void NavEKF2_core::setAidingMode()
      if (!isAiding) {
         // Don't allow filter to start position or velocity aiding until the tilt and yaw alignment is complete
         // and IMU gyro bias estimates have stabilised
-        bool filterIsStable = tiltAlignComplete && yawAlignComplete && imuCalCompleted();
+        bool filterIsStable = tiltAlignComplete && yawAlignComplete && checkGyroCalStatus();
         // If GPS usage has been prohiited then we use flow aiding provided optical flow data is present
         bool useFlowAiding = (frontend->_fusionModeGPS == 3) && optFlowDataPresent();
         // Start aiding if we have a source of aiding data and the filter attitude algnment is complete
@@ -327,17 +327,15 @@ void NavEKF2_core::recordYawReset()
     }
 }
 
-// return true when IMU calibration completed
-bool NavEKF2_core::imuCalCompleted(void)
+// return true and set the class variable true if the delta angle bias has been learned
+bool NavEKF2_core::checkGyroCalStatus(void)
 {
     // check delta angle bias variances
     const float delAngBiasVarMax = sq(radians(0.1f * dtEkfAvg));
-    bool gyroCalComplete =  (P[9][9] <= delAngBiasVarMax) &&
+    delAngBiasLearned =  (P[9][9] <= delAngBiasVarMax) &&
                             (P[10][10] <= delAngBiasVarMax) &&
                             (P[11][11] <= delAngBiasVarMax);
-
-    return gyroCalComplete;
-
+    return delAngBiasLearned;
 }
 
 // Commands the EKF to not use GPS.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -1098,16 +1098,20 @@ void NavEKF2_core::alignMagStateDeclination()
     stateStruct.earth_magfield.x = magLengthNE * cosf(magDecAng);
     stateStruct.earth_magfield.y = magLengthNE * sinf(magDecAng);
 
-    // zero the corresponding state covariances
-    float var_16 = P[16][16];
-    float var_17 = P[17][17];
-    zeroRows(P,16,17);
-    zeroCols(P,16,17);
-    P[16][16] = var_16;
-    P[17][17] = var_17;
+    if (!inhibitMagStates) {
+        // zero the corresponding state covariances if magnetic field state learning is active
+        float var_16 = P[16][16];
+        float var_17 = P[17][17];
+        zeroRows(P,16,17);
+        zeroCols(P,16,17);
+        P[16][16] = var_16;
+        P[17][17] = var_17;
 
-    // fuse the declination angle to re-establish valid covariances
-    FuseDeclination(0.1f);
+        // fuse the declination angle to establish covariances and prevent large swings in declination
+        // during initial fusion
+        FuseDeclination(0.1f);
+
+    }
 }
 
 // record a magentic field state reset event

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -428,10 +428,14 @@ void NavEKF2_core::readGpsData()
             // Set the EKF origin and magnetic field declination if not previously set  and GPS checks have passed
             if (gpsGoodToAlign && !validOrigin) {
                 setOrigin();
-                // Now we know the location we have an estimate for the magnetic field declination and adjust the earth field accordingly
+
+                // set the NE earth magnetic field states using the published declination
+                // and set the corresponding variances and covariances
                 alignMagStateDeclination();
+
                 // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
                 EKF_origin.alt = gpsloc.alt - baroDataNew.hgt;
+
             }
 
             // convert GPS measurements to local NED and save to buffer to be fused later if we have a valid origin

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -459,14 +459,13 @@ void  NavEKF2_core::getFilterStatus(nav_filter_status &status) const
 {
     // init return value
     status.value = 0;
-
     bool doingFlowNav = (PV_AidingMode == AID_RELATIVE) && flowDataValid;
     bool doingWindRelNav = !tasTimeout && assume_zero_sideslip();
     bool doingNormalGpsNav = !posTimeout && (PV_AidingMode == AID_ABSOLUTE);
     bool someVertRefData = (!velTimeout && useGpsVertVel) || !hgtTimeout;
     bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout) || doingFlowNav;
-    bool optFlowNavPossible = flowDataValid && (frontend->_fusionModeGPS == 3);
-    bool gpsNavPossible = !gpsNotAvailable && gpsGoodToAlign;
+    bool optFlowNavPossible = flowDataValid && (frontend->_fusionModeGPS == 3) && delAngBiasLearned;
+    bool gpsNavPossible = !gpsNotAvailable && gpsGoodToAlign && delAngBiasLearned;
     bool filterHealthy = healthy() && tiltAlignComplete && (yawAlignComplete || (!use_compass() && (PV_AidingMode == AID_NONE)));
     // If GPS height usage is specified, height is considered to be inaccurate until the GPS passes all checks
     bool hgtNotAccurate = (frontend->_altSource == 2) && !validOrigin;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -213,8 +213,8 @@ void NavEKF2_core::InitialiseVariables()
     tasStoreIndex = 0;
     ofStoreIndex = 0;
     delAngCorrection.zero();
-    velCorrection.zero();
-    posCorrection.zero();
+    velErrintegral.zero();
+    posErrintegral.zero();
     gpsGoodToAlign = false;
     gpsNotAvailable = true;
     motorsArmed = false;
@@ -633,54 +633,47 @@ void NavEKF2_core::calcOutputStates()
         delAngCorrection = deltaAngErr * errorGain * dtIMUavg;
 
         // calculate velocity and position tracking errors
-        Vector3f velDelta = (stateStruct.velocity - outputDataDelayed.velocity);
-        Vector3f posDelta = (stateStruct.position - outputDataDelayed.position);
+        Vector3f velErr = (stateStruct.velocity - outputDataDelayed.velocity);
+        Vector3f posErr = (stateStruct.position - outputDataDelayed.position);
 
         // collect magnitude tracking error for diagnostics
         outputTrackError.x = deltaAngErr.length();
-        outputTrackError.y = velDelta.length();
-        outputTrackError.z = posDelta.length();
+        outputTrackError.y = velErr.length();
+        outputTrackError.z = posErr.length();
 
-        // If the user specifes a time constant for the position and velocity states then calculate and apply the position
-        // and velocity corrections immediately to the whole output history which takes longer to process but enables smaller
-        // time constants to be used. Else apply the corrections to the current state only using the same time constant
-        // used for the quaternion corrections.
-        if (frontend->_tauVelPosOutput > 0) {
-            // convert time constant from centi-seconds to seconds
-            float tauPosVel = constrain_float(0.01f*(float)frontend->_tauVelPosOutput, 0.1f, 0.5f);
+        // convert user specified time constant from centi-seconds to seconds
+        float tauPosVel = constrain_float(0.01f*(float)frontend->_tauVelPosOutput, 0.1f, 0.5f);
 
-            // calculate a gain to track the EKF position states with the specified time constant
-            float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
+        // calculate a gain to track the EKF position states with the specified time constant
+        float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
 
-            // use a PI feedback to calculate a correction that will be applied to the output state history
-            posCorrection += posDelta * sq(velPosGain) * 0.1f; // I term
-            velCorrection += velDelta * sq(velPosGain) * 0.1f; // I term
-            velDelta *= velPosGain; // P term
-            posDelta *= velPosGain; // P term
+        // use a PI feedback to calculate a correction that will be applied to the output state history
+        posErrintegral += posErr;
+        velErrintegral += velErr;
+        Vector3f velCorrection = velErr * velPosGain + velErrintegral * sq(velPosGain) * 0.1f;
+        Vector3f posCorrection = posErr * velPosGain + posErrintegral * sq(velPosGain) * 0.1f;
 
-            // loop through the output filter state history and apply the corrections to the velocity and position states
-            // this method is too expensive to use for the attitude states due to the quaternion operations required
-            // but does not introduce a time delay in the 'correction loop' and allows smaller tracking time constants
-            // to be used
-            output_elements outputStates;
-            for (unsigned index=0; index < imu_buffer_length; index++) {
-                outputStates = storedOutput[index];
+        // loop through the output filter state history and apply the corrections to the velocity and position states
+        // this method is too expensive to use for the attitude states due to the quaternion operations required
+        // but does not introduce a time delay in the 'correction loop' and allows smaller tracking time constants
+        // to be used
+        output_elements outputStates;
+        for (unsigned index=0; index < imu_buffer_length; index++) {
+            outputStates = storedOutput[index];
 
-                // a constant  velocity correction is applied
-                outputStates.velocity += velDelta + velCorrection;
+            // a constant  velocity correction is applied
+            outputStates.velocity += velCorrection;
 
-                // a constant position correction is applied
-                outputStates.position += posDelta + posCorrection;
+            // a constant position correction is applied
+            outputStates.position += posCorrection;
 
-                // push the updated data to the buffer
-                storedOutput[index] = outputStates;
-            }
-
-            // update output state to corrected values
-            //outputDataDelayed = storedOutput[storedIMU.get_oldest_index()];
-            outputDataNew = storedOutput[storedIMU.get_youngest_index()];
-
+            // push the updated data to the buffer
+            storedOutput[index] = outputStates;
         }
+
+        // update output state to corrected values
+        outputDataNew = storedOutput[storedIMU.get_youngest_index()];
+
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -262,6 +262,7 @@ void NavEKF2_core::InitialiseVariables()
     yawInnovAtLastMagReset = 0.0f;
     quatAtLastMagReset = stateStruct.quat;
     magFieldLearned = false;
+    delAngBiasLearned = false;
 
     // zero data buffers
     storedIMU.reset();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -261,6 +261,7 @@ void NavEKF2_core::InitialiseVariables()
     posDownAtLastMagReset = stateStruct.position.z;
     yawInnovAtLastMagReset = 0.0f;
     quatAtLastMagReset = stateStruct.quat;
+    magFieldLearned = false;
 
     // zero data buffers
     storedIMU.reset();
@@ -1374,54 +1375,50 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
         // calculate yaw angle rel to true north
         yaw = magDecAng - magHeading;
 
-        // calculate initial filter quaternion states using yaw from magnetometer if mag heading healthy
-        // otherwise use existing heading
-        if (!badMagYaw) {
-            // store the yaw change so that it can be retrieved externally for use by the control loops to prevent yaw disturbances following a reset
-            Vector3f tempEuler;
-            stateStruct.quat.to_euler(tempEuler.x, tempEuler.y, tempEuler.z);
-            // this check ensures we accumulate the resets that occur within a single iteration of the EKF
-            if (imuSampleTime_ms != lastYawReset_ms) {
-                yawResetAngle = 0.0f;
-            }
-            yawResetAngle += wrap_PI(yaw - tempEuler.z);
-            lastYawReset_ms = imuSampleTime_ms;
-            // calculate an initial quaternion using the new yaw value
-            initQuat.from_euler(roll, pitch, yaw);
-            // zero the attitude covariances becasue the corelations will now be invalid
-            zeroAttCovOnly();
-        } else {
-            initQuat = stateStruct.quat;
+        // calculate initial filter quaternion states using yaw from magnetometer
+        // store the yaw change so that it can be retrieved externally for use by the control loops to prevent yaw disturbances following a reset
+        Vector3f tempEuler;
+        stateStruct.quat.to_euler(tempEuler.x, tempEuler.y, tempEuler.z);
+        // this check ensures we accumulate the resets that occur within a single iteration of the EKF
+        if (imuSampleTime_ms != lastYawReset_ms) {
+            yawResetAngle = 0.0f;
         }
+        yawResetAngle += wrap_PI(yaw - tempEuler.z);
+        lastYawReset_ms = imuSampleTime_ms;
+        // calculate an initial quaternion using the new yaw value
+        initQuat.from_euler(roll, pitch, yaw);
+        // zero the attitude covariances becasue the corelations will now be invalid
+        zeroAttCovOnly();
 
         // calculate initial Tbn matrix and rotate Mag measurements into NED
         // to set initial NED magnetic field states
-        initQuat.rotation_matrix(Tbn);
-        stateStruct.earth_magfield = Tbn * magDataDelayed.mag;
+        // don't do this if the earth field has already been learned
+        if (!magFieldLearned) {
+            initQuat.rotation_matrix(Tbn);
+            stateStruct.earth_magfield = Tbn * magDataDelayed.mag;
 
-        // align the NE earth magnetic field states with the published declination
-        alignMagStateDeclination();
+            // align the NE earth magnetic field states with the published declination
+            alignMagStateDeclination();
 
-        // zero the magnetic field state associated covariances
-        zeroRows(P,16,21);
-        zeroCols(P,16,21);
-        // set initial earth magnetic field variances
-        P[16][16] = sq(frontend->_magNoise);
-        P[17][17] = P[16][16];
-        P[18][18] = P[16][16];
-        // set initial body magnetic field variances
-        P[19][19] = sq(frontend->_magNoise);
-        P[20][20] = P[19][19];
-        P[21][21] = P[19][19];
+            // zero the magnetic field state associated covariances
+            zeroRows(P,16,21);
+            zeroCols(P,16,21);
+            // set initial earth magnetic field variances
+            P[16][16] = sq(frontend->_magNoise);
+            P[17][17] = P[16][16];
+            P[18][18] = P[16][16];
+            // set initial body magnetic field variances
+            P[19][19] = sq(frontend->_magNoise);
+            P[20][20] = P[19][19];
+            P[21][21] = P[19][19];
 
-        // clear bad magnetic yaw status
-        badMagYaw = false;
-
-        // clear mag state reset request
-        magStateResetRequest = false;
+        }
 
         // record the fact we have initialised the magnetic field states
         recordMagReset();
+
+        // clear mag state reset request
+        magStateResetRequest = false;
 
     } else {
         // this function should not be called if there is no compass data but if is is, return the

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1397,20 +1397,17 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
             initQuat.rotation_matrix(Tbn);
             stateStruct.earth_magfield = Tbn * magDataDelayed.mag;
 
-            // align the NE earth magnetic field states with the published declination
+            // set the NE earth magnetic field states using the published declination
+            // and set the corresponding variances and covariances
             alignMagStateDeclination();
 
-            // zero the magnetic field state associated covariances
-            zeroRows(P,16,21);
-            zeroCols(P,16,21);
-            // set initial earth magnetic field variances
-            P[16][16] = sq(frontend->_magNoise);
-            P[17][17] = P[16][16];
-            P[18][18] = P[16][16];
-            // set initial body magnetic field variances
-            P[19][19] = sq(frontend->_magNoise);
-            P[20][20] = P[19][19];
-            P[21][21] = P[19][19];
+            // set the remaining variances and covariances
+            zeroRows(P,18,21);
+            zeroCols(P,18,21);
+            P[18][18] = sq(frontend->_magNoise);
+            P[19][19] = P[18][18];
+            P[20][20] = P[18][18];
+            P[21][21] = P[18][18];
 
         }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -156,7 +156,7 @@ void NavEKF2_core::InitialiseVariables()
     finalInflightYawInit = false;
     finalInflightMagInit = false;
     dtIMUavg = 0.0025f;
-    dtEkfAvg = 0.01f;
+    dtEkfAvg = EKF_TARGET_DT;
     dt = 0;
     velDotNEDfilt.zero();
     lastKnownPositionNE.zero();
@@ -287,7 +287,6 @@ bool NavEKF2_core::InitialiseFilterBootstrap(void)
 
     // Initialise IMU data
     dtIMUavg = _ahrs->get_ins().get_loop_delta_t();
-    dtEkfAvg = MIN(0.01f,dtIMUavg);
     readIMUData();
     storedIMU.reset_history(imuDataNew);
     imuDataDelayed = imuDataNew;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -652,8 +652,8 @@ void NavEKF2_core::calcOutputStates()
             float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
 
             // use a PI feedback to calculate a correction that will be applied to the output state history
-            posCorrection += posDelta * velPosGain; // I term
-            velCorrection += velDelta * velPosGain; //  I term
+            posCorrection += posDelta * velPosGain * 0.9f; // I term
+            velCorrection += velDelta * velPosGain * 0.9f; //  I term
             velDelta *= velPosGain; // P term
             posDelta *= velPosGain; // P term
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -653,8 +653,8 @@ void NavEKF2_core::calcOutputStates()
             float velPosGain = dtEkfAvg / constrain_float(tauPosVel, dtEkfAvg, 10.0f);
 
             // use a PI feedback to calculate a correction that will be applied to the output state history
-            posCorrection += posDelta * velPosGain * 0.9f; // I term
-            velCorrection += velDelta * velPosGain * 0.9f; //  I term
+            posCorrection += posDelta * sq(velPosGain) * 0.1f; // I term
+            velCorrection += velDelta * sq(velPosGain) * 0.1f; // I term
             velDelta *= velPosGain; // P term
             posDelta *= velPosGain; // P term
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -795,6 +795,9 @@ private:
     float posDownObsNoise;          // observation noise variance on the vertical position used by the state and covariance update step (m^2)
     Vector3f delAngCorrected;       // corrected IMU delta angle vector at the EKF time horizon (rad)
     Vector3f delVelCorrected;       // corrected IMU delta velocity vector at the EKF time horizon (m/s)
+    bool magFieldLearned;           // true when the magnetic field has been learned
+    Vector3f earthMagFieldVar;      // NED earth mag field variances for last learned field (mGauss^2)
+    Vector3f bodyMagFieldVar;       // XYZ body mag field variances for last learned field (mGauss^2)
 
     Vector3f outputTrackError;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -646,6 +646,8 @@ private:
     bool badMagYaw;                 // boolean true if the magnetometer is declared to be producing bad data
     bool badIMUdata;                // boolean true if the bad IMU data is detected
 
+    const float EKF_TARGET_DT = 0.01f;    // target EKF update time step
+
     float gpsNoiseScaler;           // Used to scale the  GPS measurement noise and consistency gates to compensate for operation with small satellite counts
     Vector28 Kfusion;               // Kalman gain vector
     Matrix24 KH;                    // intermediate result used for covariance updates

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -586,6 +586,9 @@ private:
     // Assess GPS data quality and return true if good enough to align the EKF
     bool calcGpsGoodToAlign(void);
 
+    // return true when IMU calibration completed
+    bool imuCalCompleted(void);
+
     // update inflight calculaton that determines if GPS data is good enough for reliable navigation
     void calcGpsGoodForFlight(void);
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -767,8 +767,8 @@ private:
     output_elements outputDataNew;  // output state data at the current time step
     output_elements outputDataDelayed; // output state data at the current time step
     Vector3f delAngCorrection;      // correction applied to delta angles used by output observer to track the EKF
-    Vector3f velCorrection;         // correction applied to velocities used by the output observer to track the EKF
-    Vector3f posCorrection;         // correction applied to positions used by the output observer to track the EKF
+    Vector3f velErrintegral;        // integral of output predictor NED velocity tracking error (m)
+    Vector3f posErrintegral;        // integral of output predictor NED position tracking error (m.sec)
     float innovYaw;                 // compass yaw angle innovation (rad)
     uint32_t timeTasReceived_ms;    // time last TAS data was received (msec)
     bool gpsGoodToAlign;            // true when the GPS quality can be used to initialise the navigation system

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -586,8 +586,8 @@ private:
     // Assess GPS data quality and return true if good enough to align the EKF
     bool calcGpsGoodToAlign(void);
 
-    // return true when IMU calibration completed
-    bool imuCalCompleted(void);
+    // return true and set the class variable true if the delta angle bias has been learned
+    bool checkGyroCalStatus(void);
 
     // update inflight calculaton that determines if GPS data is good enough for reliable navigation
     void calcGpsGoodForFlight(void);
@@ -801,6 +801,7 @@ private:
     bool magFieldLearned;           // true when the magnetic field has been learned
     Vector3f earthMagFieldVar;      // NED earth mag field variances for last learned field (mGauss^2)
     Vector3f bodyMagFieldVar;       // XYZ body mag field variances for last learned field (mGauss^2)
+    bool delAngBiasLearned;         // true when the gyro bias has been learned
 
     Vector3f outputTrackError;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -603,7 +603,8 @@ private:
     void fuseEulerYaw();
 
     // Fuse declination angle to keep earth field declination from changing when we don't have earth relative observations.
-    void FuseDeclination();
+    // Input is 1-sigma uncertainty in published declination
+    void FuseDeclination(float declErr);
 
     // Propagate PVA solution forward from the fusion time horizon to the current time horizon
     // using a simple observer

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1270,9 +1270,6 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
                 RI : (int16_t)(100*rngInnov),
                 meaRng : (uint16_t)(100*range),
                 errHAGL : (uint16_t)(100*gndOffsetErr),
-                angErr : 0.0f,
-                velErr : 0.0f,
-                posErr : 0.0f
             };
             WriteBlock(&pkt5, sizeof(pkt5));
         }
@@ -1425,7 +1422,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     Vector3f predictorErrors; // output predictor angle, velocity and position tracking error
     ahrs.get_NavEKF2().getFlowDebug(-1,normInnov, gndOffset, flowInnovX, flowInnovY, auxFlowInnov, HAGL, rngInnov, range, gndOffsetErr);
     ahrs.get_NavEKF2().getOutputTrackingError(-1,predictorErrors);
-    struct log_EKF5 pkt5 = {
+    struct log_NKF5 pkt5 = {
         LOG_PACKET_HEADER_INIT(LOG_NKF5_MSG),
         time_us : time_us,
         normInnov : (uint8_t)(MIN(100*normInnov,255)),

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1424,7 +1424,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     float gndOffsetErr=0; // filter ground offset state error
     Vector3f predictorErrors; // output predictor angle, velocity and position tracking error
     ahrs.get_NavEKF2().getFlowDebug(-1,normInnov, gndOffset, flowInnovX, flowInnovY, auxFlowInnov, HAGL, rngInnov, range, gndOffsetErr);
-    ahrs.get_NavEKF2().getOutputTrackingError(0,predictorErrors);
+    ahrs.get_NavEKF2().getOutputTrackingError(-1,predictorErrors);
     struct log_EKF5 pkt5 = {
         LOG_PACKET_HEADER_INIT(LOG_NKF5_MSG),
         time_us : time_us,

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -352,6 +352,20 @@ struct PACKED log_EKF5 {
     int16_t RI;
     uint16_t meaRng;
     uint16_t errHAGL;
+};
+
+struct PACKED log_NKF5 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t normInnov;
+    int16_t FIX;
+    int16_t FIY;
+    int16_t AFI;
+    int16_t HAGL;
+    int16_t offset;
+    int16_t RI;
+    uint16_t meaRng;
+    uint16_t errHAGL;
     float angErr;
     float velErr;
     float posErr;
@@ -788,7 +802,7 @@ Format characters in the format string for binary log messages
     { LOG_EKF4_MSG, sizeof(log_EKF4), \
       "EKF4","QcccccccbbHBHH","TimeUS,SV,SP,SH,SMX,SMY,SMZ,SVT,OFN,OFE,FS,TS,SS,GPS" }, \
     { LOG_EKF5_MSG, sizeof(log_EKF5), \
-      "EKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,_,_,_" }, \
+      "EKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr" }, \
     { LOG_NKF1_MSG, sizeof(log_EKF1), \
       "NKF1","QccCfffffffccc","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ" }, \
     { LOG_NKF2_MSG, sizeof(log_NKF2), \
@@ -797,7 +811,7 @@ Format characters in the format string for binary log messages
       "NKF3","Qcccccchhhcc","TimeUS,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT" }, \
     { LOG_NKF4_MSG, sizeof(log_NKF4), \
       "NKF4","QcccccfbbHBHHb","TimeUS,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI" }, \
-    { LOG_NKF5_MSG, sizeof(log_EKF5), \
+    { LOG_NKF5_MSG, sizeof(log_NKF5), \
       "NKF5","QBhhhcccCCfff","TimeUS,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,eAng,eVel,ePos" }, \
     { LOG_NKF6_MSG, sizeof(log_EKF1), \
       "NKF6","QccCfffffffccc","TimeUS,Roll,Pitch,Yaw,VN,VE,VD,dPD,PN,PE,PD,GX,GY,GZ" }, \


### PR DESCRIPTION
During a take-off some toilet bowling was observed. This was traced to  learning of incorrect magnetic declination due to sensor errors that occurred just after the switch to 3D-mag fusion before the covariances on the earth field states had settled.

This PR ensures that the NE mag field state covariances are correctly initialised and that the magnetic field states learned during flight are not forgotten after landing.

The average filter time-step value dtEkfAvg was not being updated. This made bias estimation noisy and increased innovations.

The way the I term in the output predictor was being scaled meant that the overshoot/damping varied with time constant. This has been fixed and the default tuning gain adjusted to a value that provides a reasonable compromise between output tracking accuracy and noise.

Fixes to a race condition that caused the NE earth field covariances incorporating the declination uncertainty to be zeroed after initialisation. This change has reduced vulnerability of the declination estimate and therefore yaw and estimation accuracy to measurement errors in early flight.

A #define from upstream preventing use of EKF1 has been modified so that EKF1 can now be selected via parameters. We can do this on Solo because our revision of STM32 chip does not have the bug preventing use of the upper 1MB of flash in combination with high speed USB.

The following plots show the estimated declination and inclination before and after the changes:

before
![mag earth - before](https://cloud.githubusercontent.com/assets/3596952/16570949/500f74a4-4294-11e6-9e40-19ad7b7aa12e.png)

after
![mag earth - after](https://cloud.githubusercontent.com/assets/3596952/16570968/d380bb7c-4294-11e6-9b23-cee7f9699a8b.png)

The following plots show the GPS velocity innovations before and after the change - innovations are reduced:

before
![vel innov - before](https://cloud.githubusercontent.com/assets/3596952/16570996/28e8e314-4295-11e6-96f3-cf4e531a7dd6.png)

after:
![vel innov - after](https://cloud.githubusercontent.com/assets/3596952/16570971/da6efa84-4294-11e6-85ab-4290dd1331dc.png)

The following plots show gyro bias estimates before and after the change - estimation is less noisy:

before
<img width="839" alt="gyro bias - before" src="https://cloud.githubusercontent.com/assets/3596952/16555140/74a098c6-4216-11e6-93a6-4c26c2e4bd36.png">

after
<img width="827" alt="gyro bias - after" src="https://cloud.githubusercontent.com/assets/3596952/16555145/7a9bbed6-4216-11e6-807b-778a4347242c.png">
